### PR TITLE
feat: add rich contact form with Resend email integration (#18)

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,0 +1,144 @@
+// NOTE: Resend integration is scaffolded but not active.
+import { Resend } from 'resend'
+
+const resend = new Resend(process.env.RESEND_API_KEY)
+
+const NEEDS_LABELS: Record<string, string> = {
+  story_dev:  'Story development',
+  industry:   'Industry navigation',
+  pitch:      'Pitch preparation',
+  transmedia: 'Transmedia strategy',
+  legal:      'Legal & IP counsel',
+  wellbeing:  'Creator wellbeing',
+}
+
+const TIER_LABELS: Record<string, string> = {
+  foundation: 'Tier I — Foundation ($350 – $600, one-time)',
+  guidance:   'Tier II — Guidance ($1,200 – $1,800 / month)',
+  incubation: 'Tier III — Incubation ($2,500 – $4,000 / month)',
+  unsure:     'Not sure yet — would like guidance',
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json()
+
+    const {
+      first_name,
+      last_name,
+      email,
+      phone,
+      tier,
+      medium,
+      needs,
+      project,
+      referral,
+    } = body
+
+    if (!first_name || !last_name || !email || !tier || !project) {
+      return Response.json(
+        { error: 'Please complete all required fields.' },
+        { status: 400 }
+      )
+    }
+
+    const needsList = Array.isArray(needs) && needs.length
+      ? needs.map((n: string) => NEEDS_LABELS[n] ?? n).join(', ')
+      : 'None selected'
+
+    await resend.emails.send({
+      from:    process.env.CONTACT_FROM as string,
+      to:      process.env.CONTACT_TO   as string,
+      replyTo: email,
+      subject: `New Inquiry — ${TIER_LABELS[tier] ?? tier} — ${first_name} ${last_name}`,
+      html: `
+        <div style="font-family:sans-serif;max-width:620px;color:#1a1208;">
+
+          <div style="background:#0b3d38;padding:2rem 2.4rem;margin-bottom:0;">
+            <h1 style="font-family:Georgia,serif;font-weight:400;font-size:1.5rem;
+                       color:#e8b86d;margin:0;">
+              New Creative Counseling Inquiry
+            </h1>
+          </div>
+
+          <div style="border:1px solid #e4d9c8;border-top:none;padding:2rem 2.4rem;">
+
+            <table style="width:100%;border-collapse:collapse;margin-bottom:1.6rem;">
+              <tr>
+                <td style="padding:10px 0;color:#7a6245;font-size:.85rem;
+                           width:160px;vertical-align:top;">Name</td>
+                <td style="padding:10px 0;font-size:.9rem;">
+                  ${first_name} ${last_name}
+                </td>
+              </tr>
+              <tr style="border-top:1px solid #f0e8d8;">
+                <td style="padding:10px 0;color:#7a6245;font-size:.85rem;
+                           vertical-align:top;">Email</td>
+                <td style="padding:10px 0;font-size:.9rem;">
+                  <a href="mailto:${email}" style="color:#0b3d38;">${email}</a>
+                </td>
+              </tr>
+              <tr style="border-top:1px solid #f0e8d8;">
+                <td style="padding:10px 0;color:#7a6245;font-size:.85rem;
+                           vertical-align:top;">Phone</td>
+                <td style="padding:10px 0;font-size:.9rem;">
+                  ${phone || '—'}
+                </td>
+              </tr>
+              <tr style="border-top:1px solid #f0e8d8;">
+                <td style="padding:10px 0;color:#7a6245;font-size:.85rem;
+                           vertical-align:top;">Tier Interest</td>
+                <td style="padding:10px 0;font-size:.9rem;">
+                  ${TIER_LABELS[tier] ?? tier}
+                </td>
+              </tr>
+              <tr style="border-top:1px solid #f0e8d8;">
+                <td style="padding:10px 0;color:#7a6245;font-size:.85rem;
+                           vertical-align:top;">Medium</td>
+                <td style="padding:10px 0;font-size:.9rem;">
+                  ${medium || '—'}
+                </td>
+              </tr>
+              <tr style="border-top:1px solid #f0e8d8;">
+                <td style="padding:10px 0;color:#7a6245;font-size:.85rem;
+                           vertical-align:top;">Support Needed</td>
+                <td style="padding:10px 0;font-size:.9rem;">
+                  ${needsList}
+                </td>
+              </tr>
+              <tr style="border-top:1px solid #f0e8d8;">
+                <td style="padding:10px 0;color:#7a6245;font-size:.85rem;
+                           vertical-align:top;">Referral</td>
+                <td style="padding:10px 0;font-size:.9rem;">
+                  ${referral || '—'}
+                </td>
+              </tr>
+            </table>
+
+            <div style="background:#faf6ee;border-left:3px solid #c9973b;
+                        padding:1.2rem 1.4rem;margin-bottom:1rem;">
+              <div style="font-size:.75rem;letter-spacing:.15em;text-transform:uppercase;
+                          color:#8a640e;margin-bottom:.6rem;">Project / Situation</div>
+              <p style="font-size:.9rem;line-height:1.8;margin:0;color:#1a1208;">
+                ${project.replace(/\n/g, '<br>')}
+              </p>
+            </div>
+
+            <p style="font-size:.75rem;color:#7a6245;margin-top:1.4rem;">
+              Reply directly to this email to respond to ${first_name}.
+            </p>
+
+          </div>
+        </div>
+      `,
+    })
+
+    return Response.json({ success: true })
+  } catch (err) {
+    console.error('[contact] error:', err)
+    return Response.json(
+      { error: 'Failed to send. Please try again.' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1112,3 +1112,393 @@ footer {
   color: rgba(201, 151, 59, 0.35);
   text-transform: uppercase;
 }
+
+/* CONTACT FORM LAYOUT */
+.cta-inner--form {
+  display: grid;
+  grid-template-columns: 5fr 7fr;
+  gap: 6rem;
+  align-items: start;
+  text-align: left;
+  max-width: 1100px;
+}
+
+.cta-intro h2 {
+  font-family: var(--font-cormorant), serif;
+  font-weight: 400;
+  font-size: clamp(2.4rem, 4vw, 3.4rem);
+  line-height: 1.12;
+  color: var(--td);
+  margin-bottom: 1.4rem;
+}
+
+.cta-intro h2 em {
+  font-style: italic;
+  color: var(--gd);
+}
+
+.gold-rule {
+  width: 44px;
+  height: 2px;
+  background: var(--g);
+  margin-bottom: 1.6rem;
+}
+
+.cta-intro p {
+  font-size: 0.9rem;
+  line-height: 1.95;
+  font-weight: 300;
+  color: var(--tm2);
+  margin-bottom: 1.1rem;
+}
+
+.cta-intro p strong {
+  color: var(--ink);
+  font-weight: 500;
+}
+
+.tier-hint {
+  margin-top: 2.2rem;
+  border-top: 1px solid rgba(201, 151, 59, 0.2);
+  padding-top: 1.8rem;
+}
+
+.tier-hint-label {
+  font-size: 0.6rem;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--gd);
+  margin-bottom: 1rem;
+  display: block;
+}
+
+.tier-pills-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.tip {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  padding: 0.65rem 1rem;
+  border: 1px solid rgba(201, 151, 59, 0.22);
+  border-left: 2px solid var(--g);
+  background: rgba(201, 151, 59, 0.04);
+  font-size: 0.72rem;
+  color: var(--tm2);
+  transition: background 0.25s, border-color 0.25s;
+}
+
+.tip:hover {
+  background: rgba(201, 151, 59, 0.09);
+  border-color: rgba(201, 151, 59, 0.45);
+}
+
+.tip-num {
+  font-size: 0.58rem;
+  letter-spacing: 0.25em;
+  color: var(--g);
+  min-width: 48px;
+  text-transform: uppercase;
+}
+
+.tip-name {
+  font-weight: 500;
+  color: var(--ink);
+}
+
+.tip-price {
+  margin-left: auto;
+  font-size: 0.65rem;
+  color: var(--tm2);
+  white-space: nowrap;
+}
+
+/* FORM CARD */
+.cf-wrap {
+  background: var(--wh);
+  border: 1px solid rgba(201, 151, 59, 0.2);
+  padding: 3rem;
+}
+
+.cf {
+  display: flex;
+  flex-direction: column;
+  gap: 1.3rem;
+}
+
+.cf-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.2rem;
+}
+
+.cf-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.cf-label {
+  font-size: 0.6rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--gd);
+  font-weight: 500;
+}
+
+.cf-optional {
+  font-weight: 300;
+  letter-spacing: 0.1em;
+  text-transform: none;
+  color: var(--tm2);
+}
+
+.cf-input {
+  font-family: var(--font-montserrat), system-ui, sans-serif;
+  font-size: 0.82rem;
+  font-weight: 300;
+  color: var(--ink);
+  background: var(--pa);
+  border: 1px solid rgba(201, 151, 59, 0.25);
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  outline: none;
+  transition: border-color 0.25s, background 0.25s, box-shadow 0.25s;
+  width: 100%;
+  appearance: none;
+}
+
+.cf-input::placeholder {
+  color: rgba(58, 46, 24, 0.35);
+}
+
+.cf-input:focus {
+  border-color: var(--g);
+  background: var(--wh);
+  box-shadow: 0 0 0 3px rgba(201, 151, 59, 0.1);
+}
+
+.cf-select-wrap {
+  position: relative;
+}
+
+.cf-select-wrap::after {
+  content: '';
+  position: absolute;
+  right: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 0;
+  height: 0;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 5px solid var(--gd);
+  pointer-events: none;
+}
+
+.cf-select {
+  cursor: pointer;
+  padding-right: 2.4rem;
+}
+
+.cf-textarea {
+  resize: vertical;
+  min-height: 130px;
+  line-height: 1.7;
+}
+
+.cf-char-count {
+  font-size: 0.58rem;
+  color: var(--tm2);
+  text-align: right;
+  letter-spacing: 0.05em;
+  opacity: 0.7;
+}
+
+/* Checkboxes */
+.cf-checks {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  margin-top: 0.2rem;
+}
+
+.cf-check-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.7rem;
+  cursor: pointer;
+}
+
+.cf-check-item input[type='checkbox'] {
+  width: 16px;
+  height: 16px;
+  min-width: 16px;
+  border-radius: 3px;
+  background: var(--pa);
+  border: 1px solid rgba(201, 151, 59, 0.35);
+  cursor: pointer;
+  padding: 0;
+  accent-color: var(--g);
+  margin-top: 0.12rem;
+  appearance: auto;
+}
+
+.cf-check-label {
+  font-size: 0.78rem;
+  font-weight: 300;
+  color: var(--tb2);
+  line-height: 1.5;
+}
+
+.cf-check-strong {
+  font-weight: 500;
+  color: var(--ink);
+}
+
+.cf-divider {
+  border: none;
+  border-top: 1px solid rgba(201, 151, 59, 0.15);
+}
+
+/* Privacy note */
+.cf-privacy {
+  font-size: 0.68rem;
+  line-height: 1.7;
+  color: var(--tm2);
+  font-weight: 300;
+  padding: 1rem;
+  background: rgba(201, 151, 59, 0.06);
+  border-left: 2px solid rgba(201, 151, 59, 0.35);
+}
+
+.cf-privacy strong {
+  color: var(--ink);
+  font-weight: 500;
+}
+
+/* Error */
+.cf-error {
+  font-size: 0.82rem;
+  color: #b94040;
+  text-align: center;
+  padding: 0.6rem 1rem;
+  border: 1px solid rgba(185, 64, 64, 0.3);
+  border-radius: 4px;
+  background: rgba(185, 64, 64, 0.05);
+}
+
+/* Submit row */
+.cf-submit-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.cf-submit {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-family: var(--font-montserrat), system-ui, sans-serif;
+  font-size: 0.65rem;
+  font-weight: 500;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--ink);
+  background: var(--g);
+  border: none;
+  cursor: pointer;
+  padding: 0.88rem 2.4rem;
+  border-radius: 6px;
+  transition: background 0.25s, transform 0.2s;
+  white-space: nowrap;
+}
+
+.cf-submit:hover:not(:disabled) {
+  background: var(--gl);
+  transform: translateY(-2px);
+}
+
+.cf-submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.cf-arrow {
+  font-size: 0.9rem;
+  transition: transform 0.25s;
+}
+
+.cf-submit:hover:not(:disabled) .cf-arrow {
+  transform: translateX(3px);
+}
+
+.cf-submit-note {
+  font-size: 0.65rem;
+  font-weight: 300;
+  color: var(--tm2);
+  line-height: 1.6;
+  max-width: 220px;
+}
+
+/* Success state */
+.cf-success {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 4rem 2rem;
+  gap: 1.2rem;
+}
+
+.cf-success-icon {
+  width: 56px;
+  height: 56px;
+  border: 2px solid var(--g);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.cf-success-icon svg {
+  width: 24px;
+  height: 24px;
+}
+
+.cf-success h3 {
+  font-family: var(--font-cormorant), serif;
+  font-size: 1.9rem;
+  font-weight: 400;
+  color: var(--td);
+}
+
+.cf-success h3 em {
+  font-style: italic;
+  color: var(--gd);
+}
+
+.cf-success p {
+  font-size: 0.82rem;
+  line-height: 1.85;
+  font-weight: 300;
+  color: var(--tm2);
+  max-width: 360px;
+  margin: 0;
+}
+
+.cf-success-sub {
+  font-size: 0.7rem;
+  color: var(--tm2);
+}
+
+.cf-success-sub a {
+  color: var(--gd);
+  text-decoration: underline;
+}

--- a/components/CTA.tsx
+++ b/components/CTA.tsx
@@ -1,45 +1,64 @@
-import Link from 'next/link'
+import ContactForm from '@/components/ContactForm'
 
 export default function CTA() {
   return (
     <section className="cta" id="contact">
       <svg
         style={{ position: 'absolute', right: '6%', top: 0, height: '100%', opacity: 0.06, zIndex: 0 }}
-        viewBox="0 0 300 900"
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
-        aria-hidden="true"
+        viewBox="0 0 300 900" fill="none"
+        xmlns="http://www.w3.org/2000/svg" aria-hidden="true"
       >
         <path d="M30 900 L30 280 Q30 50 150 50 Q270 50 270 280 L270 900Z" fill="#0b3d38" />
       </svg>
 
-      <div className="cta-inner">
-        <div className="sl" style={{ justifyContent: 'center', marginBottom: '1.2rem' }}>
-          <div className="sl-line" style={{ background: 'var(--gd)' }} />
-          <span style={{ color: 'var(--gd)' }}>Begin Your Journey</span>
-          <div className="sl-line" style={{ background: 'var(--gd)' }} />
+      <div className="cta-inner cta-inner--form">
+
+        {/* Left panel */}
+        <div className="cta-intro reveal">
+          <div className="sl" style={{ marginBottom: '1.4rem' }}>
+            <div className="sl-line" style={{ background: 'var(--gd)' }} />
+            <span style={{ color: 'var(--gd)' }}>Begin Your Journey</span>
+          </div>
+
+          <h2>
+            Your Story Deserves<br />
+            <em>Extraordinary</em><br />
+            Counsel.
+          </h2>
+          <div className="gold-rule" />
+
+          <p>
+            Creative Counseling accepts a <strong>limited number of clients</strong> each
+            year. All inquiries are reviewed personally by Sohaib Awan.
+          </p>
+          <p>
+            If you are serious about your work and your voice in this industry — we are
+            serious about you.
+          </p>
+
+          <div className="tier-hint">
+            <span className="tier-hint-label">Available Tiers</span>
+            <div className="tier-pills-preview">
+              {[
+                { num: 'Tier I',   name: 'Foundation',  price: '$350 – $600' },
+                { num: 'Tier II',  name: 'Guidance',    price: '$1,200 – $1,800 / mo' },
+                { num: 'Tier III', name: 'Incubation',  price: '$2,500 – $4,000 / mo' },
+              ].map((t) => (
+                <div key={t.num} className="tip">
+                  <span className="tip-num">{t.num}</span>
+                  <span className="tip-name">{t.name}</span>
+                  <span className="tip-price">{t.price}</span>
+                </div>
+              ))}
+            </div>
+          </div>
         </div>
 
-        <h2 className="reveal">
-          Your Story Deserves<br />
-          <em>Extraordinary Counsel.</em>
-        </h2>
-
-        <p className="reveal">
-          Creative Counseling accepts a limited number of clients each year.
-          All inquiries are reviewed personally by Sohaib Awan. If you are
-          serious about your work and your voice in this industry — we are
-          serious about you.
-        </p>
-
-        <div className="cta-btns reveal">
-          <Link href="/contact" className="btn-t">
-            Submit Your Inquiry
-          </Link>
-          <Link href="#services" className="btn-og">
-            Review the Tiers
-          </Link>
+        {/* Right panel — form */}
+        <div className="cf-wrap reveal d1">
+          <ContactForm />
         </div>
+
       </div>
     </section>
   )

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -1,0 +1,261 @@
+'use client'
+
+import { useState } from 'react'
+
+type Fields = {
+  first_name: string
+  last_name:  string
+  email:      string
+  phone:      string
+  tier:       string
+  medium:     string
+  needs:      string[]
+  project:    string
+  referral:   string
+}
+
+type Status = 'idle' | 'loading' | 'success' | 'error'
+
+const empty: Fields = {
+  first_name: '',
+  last_name:  '',
+  email:      '',
+  phone:      '',
+  tier:       '',
+  medium:     '',
+  needs:      [],
+  project:    '',
+  referral:   '',
+}
+
+const tierOptions = [
+  { value: 'foundation', label: 'Tier I — Foundation ($350 – $600, one-time)' },
+  { value: 'guidance',   label: 'Tier II — Guidance ($1,200 – $1,800 / month)' },
+  { value: 'incubation', label: 'Tier III — Incubation ($2,500 – $4,000 / month)' },
+  { value: 'unsure',     label: 'Not sure yet — I\'d like guidance' },
+]
+
+const mediumOptions = [
+  { value: 'comics',     label: 'Comics / Graphic novels' },
+  { value: 'prose',      label: 'Prose fiction / Novels' },
+  { value: 'screenplay', label: 'Screenplay / Television' },
+  { value: 'animation',  label: 'Animation' },
+  { value: 'gaming',     label: 'Gaming / Interactive narrative' },
+  { value: 'transmedia', label: 'Transmedia / Multiple formats' },
+  { value: 'other',      label: 'Other' },
+]
+
+const needsOptions = [
+  { value: 'story_dev',  label: 'Story development',    sub: 'narrative structure, character arcs, world-building' },
+  { value: 'industry',   label: 'Industry navigation',  sub: 'introductions, career strategy, publisher relations' },
+  { value: 'pitch',      label: 'Pitch preparation',    sub: 'verbal rehearsal, written decks, loglines' },
+  { value: 'transmedia', label: 'Transmedia strategy',  sub: 'IP expansion across formats and platforms' },
+  { value: 'legal',      label: 'Legal & IP counsel',   sub: 'contracts, rights, copyright structuring' },
+  { value: 'wellbeing',  label: 'Creator wellbeing',    sub: 'burnout, imposter syndrome, sustainable practice' },
+]
+
+const MAX_CHARS = 800
+
+export default function ContactForm() {
+  const [fields, setFields] = useState<Fields>(empty)
+  const [status, setStatus] = useState<Status>('idle')
+  const [error,  setError]  = useState<string>('')
+
+  function updateField(
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>
+  ) {
+    setFields((prev) => ({ ...prev, [e.target.name]: e.target.value }))
+  }
+
+  function updateCheckbox(e: React.ChangeEvent<HTMLInputElement>) {
+    const { value, checked } = e.target
+    setFields((prev) => ({
+      ...prev,
+      needs: checked
+        ? [...prev.needs, value]
+        : prev.needs.filter((n) => n !== value),
+    }))
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setStatus('loading')
+    setError('')
+
+    try {
+      const res = await fetch('/api/contact', {
+        method:  'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body:    JSON.stringify(fields),
+      })
+
+      const data = await res.json()
+
+      if (!res.ok) {
+        setError(data.error || 'Something went wrong.')
+        setStatus('error')
+        return
+      }
+
+      setStatus('success')
+    } catch {
+      setError('Could not reach the server. Please try again.')
+      setStatus('error')
+    }
+  }
+
+  if (status === 'success') {
+    return (
+      <div className="cf-success">
+        <div className="cf-success-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="#c9973b" strokeWidth="1.8"
+               strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+        </div>
+        <h3>Inquiry <em>Received.</em></h3>
+        <p>
+          Sohaib Awan will review your submission personally and respond
+          within 1-2 weeks.
+        </p>
+        <p className="cf-success-sub">
+          In the meantime, explore the Fictional Frontiers archive at{' '}
+          <a href="https://fictionalfrontiers.com" target="_blank" rel="noopener noreferrer">
+            fictionalfrontiers.com
+          </a>
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <form className="cf" onSubmit={handleSubmit} noValidate>
+
+      {/* Name row */}
+      <div className="cf-row">
+        <label className="cf-field">
+          <span className="cf-label">First Name</span>
+          <input className="cf-input" type="text" name="first_name"
+            value={fields.first_name} onChange={updateField}
+            placeholder="Layla" required autoComplete="given-name" />
+        </label>
+        <label className="cf-field">
+          <span className="cf-label">Last Name</span>
+          <input className="cf-input" type="text" name="last_name"
+            value={fields.last_name} onChange={updateField}
+            placeholder="Hassan" required autoComplete="family-name" />
+        </label>
+      </div>
+
+      {/* Contact row */}
+      <div className="cf-row">
+        <label className="cf-field">
+          <span className="cf-label">Email Address</span>
+          <input className="cf-input" type="email" name="email"
+            value={fields.email} onChange={updateField}
+            placeholder="you@studio.com" required autoComplete="email" />
+        </label>
+        <label className="cf-field">
+          <span className="cf-label">Phone <span className="cf-optional">(Optional)</span></span>
+          <input className="cf-input" type="tel" name="phone"
+            value={fields.phone} onChange={updateField}
+            placeholder="+1 (555) 000-0000" autoComplete="tel" />
+        </label>
+      </div>
+
+      {/* Tier */}
+      <label className="cf-field">
+        <span className="cf-label">Which tier interests you?</span>
+        <div className="cf-select-wrap">
+          <select className="cf-input cf-select" name="tier"
+            value={fields.tier} onChange={updateField} required>
+            <option value="" disabled>Select a tier…</option>
+            {tierOptions.map((o) => (
+              <option key={o.value} value={o.value}>{o.label}</option>
+            ))}
+          </select>
+        </div>
+      </label>
+
+      {/* Medium */}
+      <label className="cf-field">
+        <span className="cf-label">Primary creative medium</span>
+        <div className="cf-select-wrap">
+          <select className="cf-input cf-select" name="medium"
+            value={fields.medium} onChange={updateField}>
+            <option value="" disabled>Select your medium…</option>
+            {mediumOptions.map((o) => (
+              <option key={o.value} value={o.value}>{o.label}</option>
+            ))}
+          </select>
+        </div>
+      </label>
+
+      {/* Needs checkboxes */}
+      <div className="cf-field">
+        <span className="cf-label">Areas where you need support</span>
+        <div className="cf-checks">
+          {needsOptions.map((o) => (
+            <label key={o.value} className="cf-check-item">
+              <input type="checkbox" name="needs" value={o.value}
+                checked={fields.needs.includes(o.value)}
+                onChange={updateCheckbox} />
+              <span className="cf-check-label">
+                <span className="cf-check-strong">{o.label}</span>
+                {' '}— {o.sub}
+              </span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <hr className="cf-divider" />
+
+      {/* Project description */}
+      <label className="cf-field">
+        <span className="cf-label">Tell us about your project or situation</span>
+        <textarea className="cf-input cf-textarea" name="project"
+          value={fields.project} onChange={updateField}
+          maxLength={MAX_CHARS} required rows={6}
+          placeholder="Describe your work, where you are in the process, and what you're hoping to accomplish. The more specific you are, the better we can assess fit." />
+        <span className="cf-char-count">
+          {fields.project.length} / {MAX_CHARS}
+        </span>
+      </label>
+
+      {/* Referral */}
+      <label className="cf-field">
+        <span className="cf-label">How did you hear about Creative Counseling?</span>
+        <input className="cf-input" type="text" name="referral"
+          value={fields.referral} onChange={updateField}
+          placeholder="Radio show, colleague, social media, SDCC…" />
+      </label>
+
+      <hr className="cf-divider" />
+
+      {/* Privacy note */}
+      <div className="cf-privacy">
+        <strong>A note on discretion.</strong> All inquiries are kept strictly
+        confidential. Your project details, creative work, and personal information
+        are never shared outside of our counsel relationship. Sohaib Awan reviews
+        all submissions personally.
+      </div>
+
+      {status === 'error' && (
+        <div className="cf-error">{error}</div>
+      )}
+
+      {/* Submit row */}
+      <div className="cf-submit-row">
+        <button className="cf-submit" type="submit" disabled={status === 'loading'}>
+          {status === 'loading' ? 'Sending…' : 'Submit Inquiry'}
+          {status !== 'loading' && <span className="cf-arrow">→</span>}
+        </button>
+        <p className="cf-submit-note">
+          You will receive a personal response within 1-2 weeks.
+        </p>
+      </div>
+
+    </form>
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "@vercel/analytics": "^2.0.1",
         "next": "16.2.1",
         "react": "19.2.4",
-        "react-dom": "19.2.4"
+        "react-dom": "19.2.4",
+        "resend": "^6.10.0"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -1218,6 +1219,12 @@
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -3281,6 +3288,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -4786,6 +4799,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -4939,6 +4958,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.10.0.tgz",
+      "integrity": "sha512-i7CwZpYj4Oho1RxsTpLcCUkO08+HiL4NXrm6jLJ2WzJ89UGI8eROSieLONJA3hnUrf1OYnCyfq5F6POnHUMv1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "svix": "1.88.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve": {
@@ -5310,6 +5350,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -5507,6 +5557,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.88.0",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.88.0.tgz",
+      "integrity": "sha512-vm/JrrUd3bVyBE+3L33TIyVSs8gS5fYx7lrISvKlDJXTYX1ACH4REX8P1tHxsSKoZi/rvifM1t0XRc5Vc45THw==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0",
+        "uuid": "^10.0.0"
       }
     },
     "node_modules/tinyglobby": {
@@ -5846,6 +5906,19 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "@vercel/analytics": "^2.0.1",
     "next": "16.2.1",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "resend": "^6.10.0"
   },
   "devDependencies": {
     "@types/node": "^20",


### PR DESCRIPTION
## Summary
Replaces CTA buttons with a full two-panel inquiry form. Left panel has intro copy and tier reference pills. Right panel is a white card form collecting name, email, phone, tier, creative medium, areas of need (checkboxes), project description with character counter, and referral source.
Submission posts to /api/contact which sends a formatted email via Resend with replyTo set to the inquirer's address. Animated success state replaces the form on completion.

## Resend / Domain Status
Resend integration is scaffolded but not active. Environment variables are placeholder only; form will not deliver email until
domain is hooked up and DNS verified.

## Related Issue
Closes #17 

## Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Chore / refactor
- [ ] Content update

## Checklist
- [x] Tested locally
- [x] Success state animates correctly
- [x] No console errors
- [ ] Responsive on mobile
- [x] No hardcoded secrets or emails
- [ ] Environment variables documented if added