### PR TITLE
refactor: responsive layout: nav and hero (#20)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -28,6 +28,11 @@ body {
   overflow-x: hidden;
 }
 
+html, body {
+  overflow-x: hidden;
+  width: 100%;
+}
+
 /* NAV */
 nav {
   position: fixed;
@@ -1501,4 +1506,165 @@ footer {
 .cf-success-sub a {
   color: var(--gd);
   text-decoration: underline;
+}
+
+/* ============================================================
+   RESPONSIVE — mobile-first breakpoints
+   Desktop styles are unchanged above. These rules override
+   downward from the desktop-first base using max-width.
+   ============================================================ */
+
+/* ── NAV MOBILE ── */
+@media (max-width: 768px) {
+  nav {
+    padding: 1rem 1.4rem;
+  }
+
+  .nav-links,
+  .nav-cta--desktop {
+    display: none;
+  }
+
+  .nav-burger {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 5px;
+    width: 36px;
+    height: 36px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 4px;
+    z-index: 600;
+    position: relative;
+  }
+
+  .nav-burger span {
+    display: block;
+    width: 22px;
+    height: 1.5px;
+    background: var(--wh);
+    transition: transform 0.3s ease, opacity 0.3s ease;
+    transform-origin: center;
+  }
+
+  .nav-burger.is-open span:nth-child(1) {
+    transform: translateY(6.5px) rotate(45deg);
+  }
+
+  .nav-burger.is-open span:nth-child(2) {
+    opacity: 0;
+  }
+
+  .nav-burger.is-open span:nth-child(3) {
+    transform: translateY(-6.5px) rotate(-45deg);
+  }
+
+  /* Mobile drawer */
+  .nav-drawer {
+    position: fixed;
+    inset: 0;
+    background: var(--td);
+    z-index: 550;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2rem;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.35s ease;
+  }
+
+  .nav-drawer.is-open {
+    opacity: 1;
+    pointer-events: all;
+  }
+
+  .nav-drawer-links {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2rem;
+  }
+
+  .nav-drawer-links a {
+    font-family: var(--font-cormorant), serif;
+    font-size: 2rem;
+    font-weight: 400;
+    color: var(--wh);
+    text-decoration: none;
+    letter-spacing: 0.06em;
+    transition: color 0.3s;
+  }
+
+  .nav-drawer-links a:hover {
+    color: var(--gl);
+  }
+
+  .nav-cta--mobile {
+    font-size: 0.66rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--ink);
+    background: var(--g);
+    padding: 0.88rem 2.4rem;
+    text-decoration: none;
+    border-radius: 6px;
+    transition: background 0.25s;
+  }
+
+  .nav-cta--mobile:hover {
+    background: var(--gl);
+  }
+}
+
+/* Hide burger on desktop */
+@media (min-width: 769px) {
+  .nav-burger  { display: none; }
+  .nav-drawer  { display: none; }
+}
+
+/* ── HERO MOBILE ── */
+@media (max-width: 768px) {
+  .hero-inner {
+    grid-template-columns: 1fr;
+    padding: 7rem 1.4rem 4rem;
+    gap: 3rem;
+  }
+
+  .hero-right {
+    animation: fadeUp 0.9s 0.85s forwards;
+  }
+
+  .tier-pill {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .tp-price {
+    margin-left: 0;
+    width: 100%;
+    padding-left: calc(55px + 1.2rem);
+  }
+
+  .scroll-cue {
+    display: none;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+}
+
+/* ── HERO TABLET ── */
+@media (max-width: 1024px) and (min-width: 769px) {
+  .hero-inner {
+    padding: 8rem 3rem 5rem;
+    gap: 3rem;
+  }
 }

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 
 export default function Nav() {
   const navRef = useRef<HTMLElement>(null)
+  const [menuOpen, setMenuOpen] = useState(false)
 
   useEffect(() => {
     const nav = navRef.current
@@ -18,6 +19,15 @@ export default function Nav() {
     return () => window.removeEventListener('scroll', handleScroll)
   }, [])
 
+  function handleLinkClick() {
+    setMenuOpen(false)
+  }
+
+  useEffect(() => {
+    document.body.style.overflow = menuOpen ? 'hidden' : ''
+    return () => { document.body.style.overflow = '' }
+  }, [menuOpen])
+
   return (
     <nav ref={navRef} id="mnav">
       <div className="nav-brand">
@@ -30,16 +40,41 @@ export default function Nav() {
           <span className="main">Creative Counseling</span>
         </div>
       </div>
-
+      
+      {/* Desktop links */}  
       <ul className="nav-links">
         <li><Link href="#services">Services</Link></li>
         <li><Link href="#about">Sohaib Awan</Link></li>
         <li><Link href="#voices">Voices</Link></li>
       </ul>
 
-      <Link href="#contact" className="nav-cta">
+      <Link href="#contact" className="nav-cta nav-cta--desktop" onClick={handleLinkClick}>
         Begin Inquiry
       </Link>
+
+      {/* Hamburger button */}
+      <button
+        className={`nav-burger${menuOpen ? ' is-open' : ''}`}
+        onClick={() => setMenuOpen((o) => !o)}
+        aria-label={menuOpen ? 'Close menu' : 'Open menu'}
+        aria-expanded={menuOpen}
+      >
+        <span /><span /><span />
+      </button>
+
+      {/* Mobile drawer */}
+      <div className={`nav-drawer${menuOpen ? ' is-open' : ''}`}
+        aria-hidden={!menuOpen}>
+        <ul className="nav-drawer-links">
+          <li><Link href="#services" onClick={handleLinkClick}>Services</Link></li>
+          <li><Link href="#about"    onClick={handleLinkClick}>Sohaib Awan</Link></li>
+          <li><Link href="#voices"   onClick={handleLinkClick}>Voices</Link></li>
+        </ul>
+        <Link href="#contact" className="nav-cta nav-cta--mobile"
+          onClick={handleLinkClick}>
+          Begin Inquiry
+        </Link>
+      </div>
     </nav>
   )
 }


### PR DESCRIPTION
## Summary
First responsive pass. Nav gains a hamburger button and full-screen mobile drawer with body scroll lock. Hero collapses to single column on mobile with adjusted padding and hidden scroll cue.
All breakpoints use max-width consistent with the desktop-first base.
Desktop layout is completely unchanged.

Context: desktop styles were written first for design fidelity during the initial port. This responsive layer is the planned follow-up now that the architecture is stable. See issue #19  for full rationale.

## Related Issue
Closes #19 

## Type of Change
- [ ] Feature
- [ ] Bug fix
- [x] Chore / refactor
- [ ] Content update

## Screenshots/GIFs
<img width="366" height="740" alt="mobile-nav-her0" src="https://github.com/user-attachments/assets/84b36860-9760-4471-bc97-82708b2b282c" />


## Checklist
- [x] Tested locally
- [x] No console errors
- [x] Responsive on mobile
- [x] Tested locally at 320px, 375px, 768px, 1024px
- [x] No horizontal scroll at any width
- [x] Desktop layout unchanged
- [x] No hardcoded secrets or emails
- [ ] Environment variables documented if added