### PR TITLE
fix: lazy initialize Resend and handle missing API key (#24)

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,8 +1,6 @@
 // NOTE: Resend integration is scaffolded but not active.
 import { Resend } from 'resend'
 
-const resend = new Resend(process.env.RESEND_API_KEY)
-
 const NEEDS_LABELS: Record<string, string> = {
   story_dev:  'Story development',
   industry:   'Industry navigation',
@@ -17,6 +15,11 @@ const TIER_LABELS: Record<string, string> = {
   guidance:   'Tier II — Guidance ($1,200 – $1,800 / month)',
   incubation: 'Tier III — Incubation ($2,500 – $4,000 / month)',
   unsure:     'Not sure yet — would like guidance',
+}
+
+function isResendConfigured(): boolean {
+  const key = process.env.RESEND_API_KEY
+  return typeof key === 'string' && key.length > 0 && key !== 'placeholder'
 }
 
 export async function POST(req: Request) {
@@ -41,6 +44,24 @@ export async function POST(req: Request) {
         { status: 400 }
       )
     }
+
+    // Graceful fallback while domain is pending
+    if (!isResendConfigured()) {
+      console.warn(
+        '[contact] Resend not configured — inquiry received but not delivered.',
+        { first_name, last_name, email, tier }
+      )
+      return Response.json(
+        {
+          error:
+            'Our inquiry system is not yet active. Please email us directly while we finish setup.',
+        },
+        { status: 503 }
+      )
+    }
+
+    // Lazy instantiation — only runs at request time, never at build time
+    const resend = new Resend(process.env.RESEND_API_KEY)
 
     const needsList = Array.isArray(needs) && needs.length
       ? needs.map((n: string) => NEEDS_LABELS[n] ?? n).join(', ')


### PR DESCRIPTION
-  prevent build-time failure
- add isResendConfigured guard with 503 fallback for unconfigured state

## Summary
Fixes Vercel build failure caused by Resend being instantiated at module level with a placeholder API key. Resend client is now created inside the request handler so it only runs at request time. An isResendConfigured() guard returns a 503 with a clear message when the key is missing or placeholder, so the form degrades gracefully until the domain is live.
No changes to any other file.

## Related Issue
Closes #23 

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Chore / refactor
- [ ] Content update

## Checklist
- [x] Vercel build passes with placeholder env vars
- [x] Form submits and returns 503 with clear message
      when Resend is not configured
- [x] No console errors